### PR TITLE
Fix the wrong podfile information

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,1 +1,3 @@
-pod 'SmartDeviceLink-iOS',  '4.0.0-alpha.3'
+target 'MobileWeather' do
+pod 'SmartDeviceLink-iOS',  '4.1.0'
+end


### PR DESCRIPTION
1. tag name is not existed any more for SDL iOS library 4.0.0-alpha
2. fix the Podfile format for latest version
